### PR TITLE
Fix code block styling with theme Chroma CSS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ markup:
     codeFences: true
     guessSyntax: true
     lineNos: false
-    style: dracula
+    noClasses: false
 
 # Output formats
 outputs:


### PR DESCRIPTION
## Summary
Fixed Hugo highlight configuration to use CSS classes instead of inline styles, allowing PaperMod theme's bundled Chroma CSS to properly style code blocks. This aligns local development appearance with deployed site.

## Changes
- Changed `style: dracula` to `noClasses: false` in `markup.highlight` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)